### PR TITLE
Add SoccerNet package to requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ wandb/
 .Trashes
 ehthumbs.db
 Thumbs.db
+.python-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,6 @@ sphinx-rtd-theme>=1.3.0
 # Optional: Deep Learning Utils
 timm>=0.9.0  # PyTorch Image Models
 einops>=0.6.0  # Tensor Operations
+
+# To get necessary soccer data
+SoccerNet>=0.1.62

--- a/verify_setup.py
+++ b/verify_setup.py
@@ -25,7 +25,8 @@ def verify_imports():
         'pytest',
         'black',
         'isort',
-        'flake8'
+        'flake8',
+        'SoccerNet'
     ]
 
     print("Python version:", sys.version)


### PR DESCRIPTION
This adds the SoccerNet package to the `requirements.txt` file so that it automatically installs when using `pip install requirements.txt`, and it also gets added to the verification script, `\verify_setup.py` to ensure it has been successfully installed.

Closes #2 